### PR TITLE
Added power support for the travis.yml file with ppc64le. and update go versions for package: ratelimit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ language: go
 arch:
 - amd64
 - ppc64le
-go: 1.5
+go: 1.13

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,7 @@
 # Cf. http://docs.travis-ci.com/user/languages/go/
 
 language: go
+arch:
+- amd64
+- ppc64le
 go: 1.5


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le.
This helps us simplify testing later when distributions are re-building and re-releasing.

updated the go version go:1.13